### PR TITLE
Background option

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,21 +43,39 @@ module.exports = class MonoImage extends MonoLazy {
     
     this.image = image
     this.sizes = Object.keys(this.image.sizes).map(s => parseInt(s))
-    
-    return html`
+
+    // not loaded
+    if (!this.loaded) {
+      return html`
       <div style="
-        background-size:cover;
-        background-position:center;
-        background-repeat:no-repeat;
         ${opts.fill
           ? `width:100%;height:100%;`
           : `padding-top:${image.dimensions.ratio}%;`
         }
-        ${this.loaded 
-          ? `background-image:url(${this.loaded});` 
-          : ''
-        }
       "></div>
-    `
+      `
+    // loaded and image
+    } else if (this.loaded && opts.background === false) {
+      return html`<div><img src="${this.loaded}"></div>`
+    //  loaded and background
+    } else {
+      return html`
+        <div style="
+          ${opts.fill
+            ? `width:100%;height:100%;`
+            : `padding-top:${image.dimensions.ratio}%;`
+          }
+          ${this.loaded
+            ? `
+              background-image:url(${this.loaded});
+              background-size:cover;
+              background-position:center;
+              background-repeat:no-repeat;
+            ` 
+            : ''
+          }
+        "></div>
+      `
+    }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,20 @@ var element = myimage(imagedata, {
 "></div>
 ```
 
+---
+
+Prefer an `img` tag to a `div`? Places the `img` in a `div` to preserve semantic structure.
+
+```js
+var element = myimage(imagedata, {
+  background: false
+})
+```
+
+```html
+<div><img src="image.jpg"></div>
+```
+
 ## Todo
 
 - [ ] Asserts

--- a/test.js
+++ b/test.js
@@ -9,7 +9,20 @@ var imagedata = {
   }
 }
 
+// normal instance
+
 var myimage = new MonoImage()
 var element = myimage.render(imagedata)
 
 document.body.appendChild(element)
+
+// img tag styles and instance
+
+var style = document.createElement('style')
+style.innerHTML = 'img { width: 100% }'
+document.head.appendChild(style)
+
+var myimageBg = new MonoImage()
+var elementBg = myimageBg.render(imagedata, { background: false })
+
+document.body.appendChild(elementBg)


### PR DESCRIPTION
Prefer an `img` tag to a `div`? Places the `img` in a `div` to preserve semantic structure.

```js
var element = myimage(imagedata, {
  background: false
})
```

```html
<div><img src="image.jpg"></div>
```