### PR TITLE
image element refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,15 @@
   "license": "MIT",
   "dependencies": {
     "closest-number": "^1.0.2",
+    "inline-style": "^2.0.0",
+    "is-obj": "^1.0.1",
+    "just-clone": "^3.0.0",
     "monolazy": "0.0.0",
+    "nanoassert": "^1.1.0",
     "nanohtml": "^1.2.4"
   },
   "devDependencies": {
-    "budo": "^11.2.0"
+    "budo": "^11.2.0",
+    "intersection-observer": "^0.5.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,6 @@
+if (typeof window !== 'undefined') require('intersection-observer')
 var MonoImage = require('.')
+var html = require('nanohtml')
 
 var imagedata = {
   sizes: {
@@ -9,7 +11,36 @@ var imagedata = {
   }
 }
 
-var myimage = new MonoImage()
-var element = myimage.render(imagedata)
+var basicImage = new MonoImage()
+var customImage = new MonoImage()
+var fancyImage = new MonoImage()
 
-document.body.appendChild(element)
+// no options
+var basicElement = basicImage.render(imagedata)
+
+// passing custom attributes
+var customElement = customImage.render(imagedata, { class: 'beep' })
+
+// passing attributes function for fade-in
+var fancyElement = fancyImage.render(imagedata, loaded => ({
+  class: `fancy ${loaded ? 'loaded' : ''}`,
+}))
+
+if (typeof window !== 'undefined') {
+  document.head.appendChild(html`
+    <style>
+      .fancy {
+        opacity: 0;
+        transition: opacity 1s ease;
+      }
+      .fancy.loaded { opacity: 1 }
+    </style>
+  `)
+  document.body.appendChild(basicElement)
+  document.body.appendChild(customElement)
+  document.body.appendChild(fancyElement)
+} else {
+  console.log(basicElement)
+  console.log(customElement)
+  console.log(fancyElement)
+}


### PR DESCRIPTION
This is a refactor to use a real `img` element as discussed in https://github.com/jongacnik/monoimage/issues/1, as well as introduces an adjusted api for applying attributes as explored in https://github.com/jongacnik/monoimage/pull/2.

You can just check out https://github.com/jongacnik/monoimage/blob/image/test.js for examples, but will briefly explain below as well:

## Basic usage

```js
var element = myImage.render(imagedata)
```
```html
<!-- loading -->
<img style="display:block;width:100%;padding-top:75%">

<!-- loaded -->
<img src="image.jpg" style="display:block;width:100%">
```
[nanocomponent]() requires the component node to remain consistent between renders. In this refactor, the node is always of type `img`. We leave off the `src` attribute on the loading image to avoid a request, and we set some styles for our ratio container. From my testing this seems to work well across browsers. This seems preferable to wrapping the `img` in a `div` once loaded since that may have side effects re: styling or otherwise. I know this isn't **valid**, but might be one of those cases of *ok* hax `¯\_(ツ)_/¯`

## Custom attributes

Attributes can be passed with an object as the second parameter and are applied directly to the element:

```js
var element = myImage.render(imagedata, { class: 'beep' })
```

```html
<!-- loading -->
<img class="beep" style="display:block;width:100%;padding-top:75%">

<!-- loaded -->
<img class="beep" src="image.jpg" style="display:block;width:100%">
```

You can also use this to override default styles (style object will be converted to inline styles), or pass events, etc:

```js
var element = myImage.render(imagedata, {
  style: { display: 'inline-block' },
  onclick: () => console.log('beep')
})
```

```html
<img src="image.jpg" style="display:inline-block;width:100%">
```

## Custom attributes function

Attributes can also be defined using a function as the second parameter. The function receives the loaded state of the image as a parameter for dynamic classnames or other attributes:

```js
var element = myImage.render(imagedata, loaded => ({
  class: loaded ? 'loaded' : '',
}))
```

```html
<!-- loading -->
<img style="display:block;width:100%;padding-top:75%">

<!-- loaded -->
<img class="loaded" src="image.jpg" style="display:block;width:100%">
```

## SSR

Opted for passing attributes as an object vs passing in actual dom nodes as suggested in https://github.com/jongacnik/monoimage/pull/2#issuecomment-389630640 so we can preserve accurate rendering in node:

```bash
node test.js
```
```
<img style="display:block;width:100%;padding-top:75%">
<img class="beep" style="display:block;width:100%;padding-top:75%">
<img class="fancy" style="display:block;width:100%;padding-top:75%">
```

Wanna put in that xtra effort to get all `mono-` components rendering nicely in node

## Changes

- Uses `img` element instead of `div` element
- Pass attributes with second parameter
- Removed `fill` option since can just override with styles
- Couple more dependencies, but all are tiny