### PR TITLE
image refactor and custom element

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "closest-number": "^1.0.2",
     "monolazy": "0.0.0",
+    "nanoassert": "^1.1.0",
     "nanohtml": "^1.2.4"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+var html = require('nanohtml')
 var MonoImage = require('.')
 
 var imagedata = {
@@ -9,7 +10,29 @@ var imagedata = {
   }
 }
 
-var myimage = new MonoImage()
-var element = myimage.render(imagedata)
+var aImage = new MonoImage()
+var bImage = new MonoImage()
+var cImage = new MonoImage()
 
-document.body.appendChild(element)
+// no options
+var aElement = aImage.render(imagedata)
+
+// custom element
+var bElement = bImage.render(imagedata, {
+  element: loaded => html`<img class="${loaded ? 'loaded' : ''}">`
+})
+
+// custom element using div
+var cElement = cImage.render(imagedata, {
+  element: loaded => html`<div></div>`
+})
+
+if (typeof window !== 'undefined') {
+  document.body.appendChild(aElement)
+  document.body.appendChild(bElement)
+  document.body.appendChild(cElement)
+} else {
+  console.log(aElement)
+  console.log(bElement)
+  console.log(cElement)
+}


### PR DESCRIPTION
Continuation of https://github.com/jongacnik/monoimage/pull/3

Refactor to use a real `img` element as discussed in https://github.com/jongacnik/monoimage/issues/1, as well as introduces an option for customizing the element as explored in https://github.com/jongacnik/monoimage/pull/2.

## Basic usage

```js
var element = myImage.render(imagedata)
```
```html
<!-- loading -->
<img style="display:block;width:100%;padding-top:75%">

<!-- loaded -->
<img src="image.jpg" style="display:block;width:100%">
```

## Element option

`element` should be a function which returns an element. Use the `loaded` param to conditionally apply attributes/values based on whether element is loaded or not.

```js
var element = myImage.render(imagedata, {
  element: loaded => html`<img class="${loaded ? 'loaded' : ''}">`
})
```
```html
<!-- loading -->
<img style="display:block;width:100%;padding-top:75%">

<!-- loaded -->
<img src="image.jpg" style="display:block;width:100%" class="loaded">
```

## Node

For the time being, styles are not applied to element in node. This should be able to be added later using some [string manipulation](https://gist.github.com/jongacnik/7725813a861b8faace4aa06e19a863f0)