### PR TITLE
noscript support

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = class MonoImage extends MonoLazy {
 
   onEnter () {
     if (this.loaded) return
-      
+
     // find best image size for the container
     var elWidth = this.element.offsetWidth * this.deviceRatio
     var imgWidth = closest(this.sizes, elWidth)
@@ -45,43 +45,76 @@ module.exports = class MonoImage extends MonoLazy {
 
   createElement (image, opts) {
     opts = opts || {}
-    
+
     this.image = image
-    this.sizes = Object.keys(this.image.sizes).map(s => parseInt(s))
+    this.sizes = Object.keys(this.image.sizes).map(s => parseInt(s)).sort()
     if (typeof opts.onload === 'function') this.handleCallback = opts.onload
 
-    var attributes = {
-      class: `monoimage${this.loaded ? ' monoimage-loaded' : ''}`
-    }
+    var els = []
 
-    var styles = `
-      width:100%;
-      display:${opts.inline ? 'inline-block' : 'block'};
-    `
+    // first iteration constructs lazy-loaded element
+    // second iteration constructs noscript vanilla element
+    for (var i = 0; i < 2; i++) {
+      var noscript = (i == 1)
 
-    if (opts.background) {
-      styles += `
-        background-position:center;
-        background-repeat:no-repeat;
-        background-size:${opts.background === 'contain' ? 'contain' : 'cover'};
-        ${this.loaded ? `background-image:url(${this.loaded});` : ''}
-      `
-    } else {
-      if (this.loaded) {
-        attributes.src = this.loaded  
+      var attributes = {
+        class: `monoimage${(this.loaded || noscript) ? ' monoimage-loaded' : ''}`
       }
+
+      var display = opts.inline ? 'inline-block' : 'block'
+
+      // the lazy-loaded element should be hidden until
+      // javascript runs on the client (only applicable for SSR)
+      if (typeof window == 'undefined' && !noscript) {
+        display = 'none'
+      }
+
+      var styles = `
+        width:100%;
+        display:${display};
+      `
+
+      if (opts.background) {
+        styles += `
+          background-position:center;
+          background-repeat:no-repeat;
+          background-size:${opts.background === 'contain' ? 'contain' : 'cover'};
+        `
+      }
+
+      if (this.loaded || noscript) {
+        // noscript elements load largest image size to be safe
+        var largestWidth = this.sizes[this.sizes.length - 1]
+        var src = this.loaded || this.image.sizes[largestWidth]
+
+        if (opts.background) {
+          styles += `
+            background-image:url(${src});
+          `
+        } else {
+          attributes.src = src
+        }
+      }
+
+      if (opts.fill) {
+        styles += 'height:100%;'
+      } else if ((!this.loaded && !noscript) || opts.background) {
+        styles += `padding-top:${image.dimensions.ratio}%;`
+      }
+
+      attributes.style = styles.replace((/  |\r\n|\n|\r/gm),"")
+
+      var el = opts.background
+        ? html`<div ${attributes}></div>`
+        : html`<img ${attributes}>`
+
+      if (noscript) {
+        el = html`<noscript>${el}</noscript>`
+      }
+
+      els.push(el)
     }
 
-    if (opts.fill) {
-      styles += 'height:100%;'
-    } else if (!this.loaded || opts.background) {
-      styles += `padding-top:${image.dimensions.ratio}%;`
-    }
-
-    attributes.style = styles.replace((/  |\r\n|\n|\r/gm),"")
-
-    return opts.background
-      ? html`<div ${attributes}></div>`
-      : html`<img ${attributes}>`
+    return html`<div>${els}</div>`
   }
 }


### PR DESCRIPTION
This is a first pass at implementing noscript.

Unfortunately implementing this cleanly is more difficult than I thought. There seems to be no good way to hide the non-noscript element from a browser that is in noscript mode. This implementation sets the non-noscript element to `display:none;` until client-side JS runs, but this seems less than ideal as it means image containers won't take shape until the JS bundle is executed.

Let me know if you have any thoughts here...

EDIT: or perhaps hiding the non-noscript element should not work out of the box but instead require pasting a [snippet of code](https://stackoverflow.com/a/15835541) into the head? lazysizes seems to [suggest this](https://github.com/aFarkas/lazysizes#the-noscript-pattern), but it's not clear to me how the .no-js class gets added/removed.